### PR TITLE
Sync README with current CLI configuration commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ Project config overrides user config field-by-field. If no config is found, sens
 ### Config Commands
 
 ```bash
+# Show merged configuration (defaults + user + project overrides)
+spanshot config show
+
 # Show config file paths and status
 spanshot config path
 
@@ -212,7 +215,7 @@ Each line is a JSON event:
 **Capture (in progress):**
 
 - Regex patterns only (no keyword or log-level detectors yet)
-- No YAML configuration file support yet (CLI flags only)
+- Capture pipeline implemented in library only (CLI commands `capture`/`run` not yet wired)
 - No hard limit on post-window event count (bounded by `postWindowDuration` only; in high-throughput scenarios, memory usage scales with log volume within that time window)
 
 **Not Yet Built:**


### PR DESCRIPTION
## Summary
- document `spanshot config show` alongside existing config commands
- update capture limitations to note library-only pipeline and remove outdated YAML restriction

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934e24578108329b95b784406c01d1e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about the `spanshot config show` command to display merged configuration including defaults, user settings, and project overrides.
  * Updated limitations section to clarify that the capture pipeline is implemented in the library but not yet integrated into CLI commands.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->